### PR TITLE
Add optional filters to lessons REST endpoint

### DIFF
--- a/includes/class-rest-api.php
+++ b/includes/class-rest-api.php
@@ -3,12 +3,15 @@ add_action('rest_api_init', function(){
   register_rest_route('ielts/v1','/lessons', [
     'methods'  => 'GET',
     'callback' => function(WP_REST_Request $req){
-      $level = sanitize_text_field($req->get_param('level') ?? '');
-      $category = sanitize_text_field($req->get_param('category') ?? '');
+      $level    = sanitize_text_field($req->get_param('level'));
+      $category = sanitize_text_field($req->get_param('category'));
+      $limit    = absint($req->get_param('limit')) ?: 12;
+      $limit    = min($limit, 50);
       $args = [
-        'post_type' => 'ielts_lesson',
-        'posts_per_page' => 20,
-        'meta_query' => array_filter([
+        'post_type'      => 'ielts_lesson',
+        'posts_per_page' => $limit,
+        'post_status'    => 'publish',
+        'meta_query'     => array_filter([
           $level ? ['key'=>'_ielts_level','value'=>$level] : null,
           $category ? ['key'=>'_ielts_category','value'=>$category] : null,
         ])
@@ -16,13 +19,15 @@ add_action('rest_api_init', function(){
       $q = new WP_Query($args);
       $items = [];
       while($q->have_posts()){ $q->the_post();
+        $id = get_the_ID();
         $items[] = [
-          'id' => get_the_ID(),
+          'id' => $id,
           'title' => get_the_title(),
           'permalink' => get_permalink(),
           'excerpt' => get_the_excerpt(),
-          'level' => get_post_meta(get_the_ID(),'_ielts_level',true),
-          'category' => get_post_meta(get_the_ID(),'_ielts_category',true),
+          'level' => get_post_meta($id,'_ielts_level',true),
+          'category' => get_post_meta($id,'_ielts_category',true),
+          'featured_image_url' => ielts_get_featured_image_url($id),
         ];
       }
       wp_reset_postdata();

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -9,3 +9,10 @@ function ielts_get_template($file, $args = []){
   if (!empty($args)) extract($args);
   include $path;
 }
+
+function ielts_get_featured_image_url($post_id, $size = 'full'){
+  $thumb_id = get_post_thumbnail_id($post_id);
+  if(!$thumb_id) return '';
+  $img = wp_get_attachment_image_src($thumb_id, $size);
+  return $img ? $img[0] : '';
+}


### PR DESCRIPTION
## Summary
- expose lessons REST API with level, category, and limit filters
- include featured image URLs using a helper

## Testing
- `php -l includes/class-rest-api.php`
- `php -l includes/helpers.php`

## Rollback
- revert commit `bf583ce`


------
https://chatgpt.com/codex/tasks/task_e_68b4a97191a08333a90c2b6c87971902