### PR TITLE
Add lesson CPT shortcode and conditional assets

### DIFF
--- a/ielts-migration.php
+++ b/ielts-migration.php
@@ -16,8 +16,13 @@ define('IELTS_MIGRATION_URL', plugin_dir_url(__FILE__));
 require_once IELTS_MIGRATION_DIR.'includes/helpers.php';
 require_once IELTS_MIGRATION_DIR.'includes/class-assets.php';
 require_once IELTS_MIGRATION_DIR.'includes/class-custom-posts.php';
+require_once IELTS_MIGRATION_DIR.'includes/class-shortcodes.php';
 require_once IELTS_MIGRATION_DIR.'includes/class-rest-api.php';
 require_once IELTS_MIGRATION_DIR.'includes/class-purchases.php';
+
+new IELTS_Assets();
+new IELTS_Custom_Posts();
+new IELTS_Shortcodes();
 
 if ( file_exists(IELTS_MIGRATION_DIR.'integrations/woocommerce.php') ) require_once IELTS_MIGRATION_DIR.'integrations/woocommerce.php';
 if ( file_exists(IELTS_MIGRATION_DIR.'integrations/seo.php') )          require_once IELTS_MIGRATION_DIR.'integrations/seo.php';

--- a/includes/class-assets.php
+++ b/includes/class-assets.php
@@ -1,6 +1,28 @@
 <?php
-add_action('wp_enqueue_scripts', function(){
-  // فقط در صفحات لازم بارگذاری شود؛ بعداً شرط بگذار
-  wp_register_style('ielts-frontend', IELTS_MIGRATION_URL.'public/css/frontend.css', [], IELTS_MIGRATION_VER);
-  wp_register_script('ielts-frontend', IELTS_MIGRATION_URL.'public/js/frontend.js', ['jquery'], IELTS_MIGRATION_VER, true);
-});
+/**
+ * Manage plugin assets.
+ */
+class IELTS_Assets {
+    public function __construct() {
+        add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_frontend' ] );
+    }
+
+    /**
+     * Enqueue frontend assets when needed.
+     */
+    public function enqueue_frontend() : void {
+        if ( ! is_singular() ) {
+            return;
+        }
+
+        global $post;
+        if ( isset( $post->post_content ) && has_shortcode( $post->post_content, 'ielts_lessons' ) ) {
+            wp_enqueue_style(
+                'ielts-frontend',
+                IELTS_MIGRATION_URL . 'public/css/frontend.css',
+                [],
+                IELTS_MIGRATION_VER
+            );
+        }
+    }
+}

--- a/includes/class-custom-posts.php
+++ b/includes/class-custom-posts.php
@@ -1,30 +1,53 @@
 <?php
-add_action('init', function(){
-  register_post_type('ielts_lesson', [
-    'label' => __('Lessons','ielts-migration'),
-    'public' => true,
-    'show_in_rest' => true,
-    'has_archive' => true,
-    'rewrite' => ['slug' => 'lesson'],
-    'supports' => ['title','editor','excerpt','thumbnail','custom-fields'],
-    'menu_icon' => 'dashicons-welcome-learn-more',
-  ]);
-  register_post_type('ielts_kit', [
-    'label' => __('Kits','ielts-migration'),
-    'public' => true,
-    'show_in_rest' => true,
-    'has_archive' => true,
-    'rewrite' => ['slug' => 'kits'],
-    'supports' => ['title','editor','excerpt','thumbnail','custom-fields'],
-    'menu_icon' => 'dashicons-portfolio',
-  ]);
-  register_post_type('ielts_practice', [
-    'label' => __('Practices','ielts-migration'),
-    'public' => true,
-    'show_in_rest' => true,
-    'has_archive' => true,
-    'rewrite' => ['slug' => 'practice'],
-    'supports' => ['title','editor','custom-fields'],
-    'menu_icon' => 'dashicons-edit',
-  ]);
-});
+/**
+ * Register custom post types for IELTS plugin.
+ */
+class IELTS_Custom_Posts {
+    public function __construct() {
+        add_action( 'init', [ $this, 'register_post_types' ] );
+    }
+
+    /**
+     * Register plugin post types.
+     */
+    public function register_post_types() : void {
+        register_post_type( 'ielts_lesson', [
+            'labels' => [
+                'name'          => __( 'Lessons', 'ielts-migration' ),
+                'singular_name' => __( 'Lesson', 'ielts-migration' ),
+            ],
+            'public'       => true,
+            'show_in_rest' => true,
+            'has_archive'  => true,
+            'rewrite'      => [ 'slug' => 'lesson' ],
+            'supports'     => [ 'title', 'editor', 'excerpt', 'thumbnail', 'custom-fields' ],
+            'menu_icon'    => 'dashicons-welcome-learn-more',
+        ] );
+
+        register_post_type( 'ielts_kit', [
+            'labels' => [
+                'name'          => __( 'Kits', 'ielts-migration' ),
+                'singular_name' => __( 'Kit', 'ielts-migration' ),
+            ],
+            'public'       => true,
+            'show_in_rest' => true,
+            'has_archive'  => true,
+            'rewrite'      => [ 'slug' => 'kits' ],
+            'supports'     => [ 'title', 'editor', 'excerpt', 'thumbnail', 'custom-fields' ],
+            'menu_icon'    => 'dashicons-portfolio',
+        ] );
+
+        register_post_type( 'ielts_practice', [
+            'labels' => [
+                'name'          => __( 'Practices', 'ielts-migration' ),
+                'singular_name' => __( 'Practice', 'ielts-migration' ),
+            ],
+            'public'       => true,
+            'show_in_rest' => true,
+            'has_archive'  => true,
+            'rewrite'      => [ 'slug' => 'practice' ],
+            'supports'     => [ 'title', 'editor', 'custom-fields' ],
+            'menu_icon'    => 'dashicons-edit',
+        ] );
+    }
+}

--- a/includes/class-shortcodes.php
+++ b/includes/class-shortcodes.php
@@ -1,37 +1,57 @@
 <?php
-// Shortcodes for IELTS plugin
-add_action('init', function () {
-  add_shortcode('ielts_lessons', function($atts){
-    $atts = shortcode_atts([
-      'level'    => '',
-      'category' => '',
-      'limit'    => 12
-    ], $atts, 'ielts_lessons');
-
-    ob_start();
-
-    $q = new WP_Query([
-      'post_type'      => 'ielts_lesson',
-      'posts_per_page' => (int)$atts['limit'],
-      'meta_query'     => array_values(array_filter([
-        $atts['level'] ? [
-          'key'   => '_ielts_level',
-          'value' => sanitize_text_field($atts['level'])
-        ] : null,
-        $atts['category'] ? [
-          'key'   => '_ielts_category',
-          'value' => sanitize_text_field($atts['category'])
-        ] : null,
-      ]))
-    ]);
-
-    echo '<div class="ielts-grid">';
-    while ($q->have_posts()) { $q->the_post();
-      ielts_get_template('shortcode-lessons.php', ['id' => get_the_ID()]);
+/**
+ * Shortcodes for IELTS plugin.
+ */
+class IELTS_Shortcodes {
+    public function __construct() {
+        add_shortcode( 'ielts_lessons', [ $this, 'render_lessons' ] );
     }
-    echo '</div>';
-    wp_reset_postdata();
 
-    return ob_get_clean();
-  });
-});
+    /**
+     * Render lessons grid.
+     *
+     * @param array $atts Shortcode attributes.
+     * @return string
+     */
+    public function render_lessons( $atts ) : string {
+        $atts = shortcode_atts(
+            [
+                'level'    => '',
+                'category' => '',
+                'limit'    => 12,
+            ],
+            $atts,
+            'ielts_lessons'
+        );
+
+        $level    = sanitize_text_field( $atts['level'] );
+        $category = sanitize_text_field( $atts['category'] );
+        $limit    = (int) $atts['limit'];
+
+        $meta_query = array_filter(
+            [
+                $level ? [ 'key' => '_ielts_level', 'value' => $level ] : null,
+                $category ? [ 'key' => '_ielts_category', 'value' => $category ] : null,
+            ]
+        );
+
+        $q = new WP_Query(
+            [
+                'post_type'      => 'ielts_lesson',
+                'posts_per_page' => $limit,
+                'meta_query'     => array_values( $meta_query ),
+            ]
+        );
+
+        ob_start();
+        echo '<div class="ielts-grid">';
+        while ( $q->have_posts() ) {
+            $q->the_post();
+            ielts_get_template( 'shortcode-lessons.php', [ 'id' => get_the_ID() ] );
+        }
+        echo '</div>';
+        wp_reset_postdata();
+
+        return ob_get_clean();
+    }
+}

--- a/public/css/frontend.css
+++ b/public/css/frontend.css
@@ -1,0 +1,10 @@
+.ielts-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.ielts-card {
+  border: 1px solid #ddd;
+  padding: 1rem;
+}

--- a/templates/shortcode-lessons.php
+++ b/templates/shortcode-lessons.php
@@ -2,6 +2,8 @@
 $id = $args['id'] ?? get_the_ID();
 ?>
 <article class="ielts-card">
-  <h3><a href="<?php echo esc_url(get_permalink($id)); ?>"><?php echo esc_html(get_the_title($id)); ?></a></h3>
-  <p><?php echo esc_html(get_the_excerpt($id)); ?></p>
+  <h3><a href="<?php echo esc_url( get_permalink( $id ) ); ?>"><?php echo esc_html( get_the_title( $id ) ); ?></a></h3>
+  <?php if ( has_excerpt( $id ) ) : ?>
+    <p><?php echo esc_html( get_the_excerpt( $id ) ); ?></p>
+  <?php endif; ?>
 </article>


### PR DESCRIPTION
## Summary
- register `ielts_lesson` custom post type and other CPTs through a new `IELTS_Custom_Posts` class
- introduce `IELTS_Shortcodes` class for `[ielts_lessons]` grid output using a template
- add `IELTS_Assets` class to conditionally enqueue a minimal frontend stylesheet only when the shortcode is present

## Testing steps
- `php -l ielts-migration.php`
- `php -l includes/class-custom-posts.php`
- `php -l includes/class-shortcodes.php`
- `php -l includes/class-assets.php`
- `php -l templates/shortcode-lessons.php`

## Rollback
- Revert the commit or deactivate the plugin


------
https://chatgpt.com/codex/tasks/task_e_68b48881f5648333b8aaa89999c9e61c