### PR TITLE
Document lessons endpoint and sanitize image helper

### DIFF
--- a/includes/class-rest-api.php
+++ b/includes/class-rest-api.php
@@ -1,6 +1,9 @@
 <?php
+/**
+ * Register REST route for lesson queries.
+ */
 add_action('rest_api_init', function(){
-  register_rest_route('ielts/v1','/lessons', [
+  register_rest_route('ielts/v1', '/lessons', [
     'methods'  => 'GET',
     'callback' => function(WP_REST_Request $req){
       $level    = sanitize_text_field($req->get_param('level'));
@@ -12,26 +15,26 @@ add_action('rest_api_init', function(){
         'posts_per_page' => $limit,
         'post_status'    => 'publish',
         'meta_query'     => array_filter([
-          $level ? ['key'=>'_ielts_level','value'=>$level] : null,
-          $category ? ['key'=>'_ielts_category','value'=>$category] : null,
+          $level ? ['key' => '_ielts_level', 'value' => $level] : null,
+          $category ? ['key' => '_ielts_category', 'value' => $category] : null,
         ])
       ];
-      $q = new WP_Query($args);
+      $query = new WP_Query($args);
       $items = [];
-      while($q->have_posts()){ $q->the_post();
+      while($query->have_posts()){ $query->the_post();
         $id = get_the_ID();
         $items[] = [
           'id' => $id,
           'title' => get_the_title(),
           'permalink' => get_permalink(),
           'excerpt' => get_the_excerpt(),
-          'level' => get_post_meta($id,'_ielts_level',true),
-          'category' => get_post_meta($id,'_ielts_category',true),
+          'level' => get_post_meta($id, '_ielts_level', true),
+          'category' => get_post_meta($id, '_ielts_category', true),
           'featured_image_url' => ielts_get_featured_image_url($id),
         ];
       }
       wp_reset_postdata();
-      return rest_ensure_response(['items'=>$items]);
+      return rest_ensure_response(['items' => $items]);
     },
     'permission_callback' => '__return_true'
   ]);

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -10,7 +10,15 @@ function ielts_get_template($file, $args = []){
   include $path;
 }
 
+/**
+ * Get the URL of a post's featured image.
+ *
+ * @param int    $post_id Post ID.
+ * @param string $size    Image size.
+ * @return string Image URL or empty string.
+ */
 function ielts_get_featured_image_url($post_id, $size = 'full'){
+  $post_id  = absint($post_id);
   $thumb_id = get_post_thumbnail_id($post_id);
   if(!$thumb_id) return '';
   $img = wp_get_attachment_image_src($thumb_id, $size);


### PR DESCRIPTION
## Summary
- document `/ielts/v1/lessons` REST route and ensure filter params are sanitized
- add docblock and absint validation for `ielts_get_featured_image_url`

## Testing
- `php -l includes/class-rest-api.php`
- `php -l includes/helpers.php`

## Rollback
- Revert commit 605c1a9 with `git revert 605c1a9`


------
https://chatgpt.com/codex/tasks/task_e_68b4af478f948333977b8f60add3bfa6