### PR TITLE
Load IELTS-IMMIGRATION translation domain

### DIFF
--- a/ielts-migration.php
+++ b/ielts-migration.php
@@ -4,7 +4,8 @@
  * Description: مدیریت درس‌ها/کیت‌ها/تمرین‌ها + REST + پرداخت/لایسنس (سازگار با Woo، Elementor، WPBakery، WPML/Polylang)
  * Version: 0.1.0
  * Author: IELTS & Immigration
- * Text Domain: ielts-migration
+ * Text Domain: IELTS-IMMIGRATION
+ * Domain Path: /languages
  */
 
 if ( ! defined('ABSPATH') ) exit;
@@ -26,7 +27,10 @@ new IELTS_Assets();
 new IELTS_Custom_Posts();
 new IELTS_Shortcodes();
 new IELTS_Shortcodes_Home();
-add_action( 'plugins_loaded', static function(){ new IELTS_Admin(); } );
+add_action( 'plugins_loaded', static function() {
+    load_plugin_textdomain( 'IELTS-IMMIGRATION', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+    new IELTS_Admin();
+} );
 
 if ( file_exists(IELTS_MIGRATION_DIR.'integrations/woocommerce.php') ) require_once IELTS_MIGRATION_DIR.'integrations/woocommerce.php';
 if ( file_exists(IELTS_MIGRATION_DIR.'integrations/seo.php') )          require_once IELTS_MIGRATION_DIR.'integrations/seo.php';

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -21,8 +21,8 @@ class IELTS_Admin {
      */
     public function register_menu() : void {
         add_menu_page(
-            __( 'IELTS Immigration', 'ielts-migration' ),
-            __( 'IELTS Immigration', 'ielts-migration' ),
+            __( 'IELTS Immigration', 'IELTS-IMMIGRATION' ),
+            __( 'IELTS Immigration', 'IELTS-IMMIGRATION' ),
             'manage_options',
             self::MENU_SLUG,
             [ $this, 'render_dashboard' ],
@@ -58,19 +58,19 @@ class IELTS_Admin {
         }
         ?>
         <div class="wrap">
-            <h1><?php echo esc_html__( 'IELTS Immigration', 'ielts-migration' ); ?></h1>
+            <h1><?php echo esc_html__( 'IELTS Immigration', 'IELTS-IMMIGRATION' ); ?></h1>
 
-            <h2 class="title ielts-admin-section"><?php echo esc_html__( 'Overview', 'ielts-migration' ); ?></h2>
-            <p><?php echo esc_html__( 'Coming soon…', 'ielts-migration' ); ?></p>
+            <h2 class="title ielts-admin-section"><?php echo esc_html__( 'Overview', 'IELTS-IMMIGRATION' ); ?></h2>
+            <p><?php echo esc_html__( 'Coming soon…', 'IELTS-IMMIGRATION' ); ?></p>
 
-            <h2 class="title ielts-admin-section"><?php echo esc_html__( 'Shortcodes', 'ielts-migration' ); ?></h2>
-            <p><?php echo esc_html__( 'Coming soon…', 'ielts-migration' ); ?></p>
+            <h2 class="title ielts-admin-section"><?php echo esc_html__( 'Shortcodes', 'IELTS-IMMIGRATION' ); ?></h2>
+            <p><?php echo esc_html__( 'Coming soon…', 'IELTS-IMMIGRATION' ); ?></p>
 
-            <h2 class="title ielts-admin-section"><?php echo esc_html__( 'REST', 'ielts-migration' ); ?></h2>
-            <p><?php echo esc_html__( 'Coming soon…', 'ielts-migration' ); ?></p>
+            <h2 class="title ielts-admin-section"><?php echo esc_html__( 'REST', 'IELTS-IMMIGRATION' ); ?></h2>
+            <p><?php echo esc_html__( 'Coming soon…', 'IELTS-IMMIGRATION' ); ?></p>
 
-            <h2 class="title ielts-admin-section"><?php echo esc_html__( 'Logs', 'ielts-migration' ); ?></h2>
-            <p><?php echo esc_html__( 'Coming soon…', 'ielts-migration' ); ?></p>
+            <h2 class="title ielts-admin-section"><?php echo esc_html__( 'Logs', 'IELTS-IMMIGRATION' ); ?></h2>
+            <p><?php echo esc_html__( 'Coming soon…', 'IELTS-IMMIGRATION' ); ?></p>
         </div>
         <?php
     }

--- a/includes/class-custom-posts.php
+++ b/includes/class-custom-posts.php
@@ -13,8 +13,8 @@ class IELTS_Custom_Posts {
     public function register_post_types() : void {
         register_post_type( 'ielts_lesson', [
             'labels' => [
-                'name'          => __( 'Lessons', 'ielts-migration' ),
-                'singular_name' => __( 'Lesson', 'ielts-migration' ),
+                'name'          => __( 'Lessons', 'IELTS-IMMIGRATION' ),
+                'singular_name' => __( 'Lesson', 'IELTS-IMMIGRATION' ),
             ],
             'public'       => true,
             'show_in_rest' => true,
@@ -26,8 +26,8 @@ class IELTS_Custom_Posts {
 
         register_post_type( 'ielts_kit', [
             'labels' => [
-                'name'          => __( 'Kits', 'ielts-migration' ),
-                'singular_name' => __( 'Kit', 'ielts-migration' ),
+                'name'          => __( 'Kits', 'IELTS-IMMIGRATION' ),
+                'singular_name' => __( 'Kit', 'IELTS-IMMIGRATION' ),
             ],
             'public'       => true,
             'show_in_rest' => true,
@@ -39,8 +39,8 @@ class IELTS_Custom_Posts {
 
         register_post_type( 'ielts_practice', [
             'labels' => [
-                'name'          => __( 'Practices', 'ielts-migration' ),
-                'singular_name' => __( 'Practice', 'ielts-migration' ),
+                'name'          => __( 'Practices', 'IELTS-IMMIGRATION' ),
+                'singular_name' => __( 'Practice', 'IELTS-IMMIGRATION' ),
             ],
             'public'       => true,
             'show_in_rest' => true,

--- a/includes/class-shortcodes-home.php
+++ b/includes/class-shortcodes-home.php
@@ -99,19 +99,19 @@ class IELTS_Shortcodes_Home {
     public function render_paths() : string {
         $paths = [
             [
-                'title' => __( 'IELTS', 'ielts-migration' ),
+                'title' => __( 'IELTS', 'IELTS-IMMIGRATION' ),
                 'url'   => esc_url( home_url( '/ielts' ) ),
             ],
             [
-                'title' => __( 'مهاجرت استرالیا', 'ielts-migration' ),
+                'title' => __( 'مهاجرت استرالیا', 'IELTS-IMMIGRATION' ),
                 'url'   => esc_url( home_url( '/australia-immigration' ) ),
             ],
             [
-                'title' => __( 'فروشگاه', 'ielts-migration' ),
+                'title' => __( 'فروشگاه', 'IELTS-IMMIGRATION' ),
                 'url'   => esc_url( home_url( '/shop' ) ),
             ],
             [
-                'title' => __( 'وبلاگ', 'ielts-migration' ),
+                'title' => __( 'وبلاگ', 'IELTS-IMMIGRATION' ),
                 'url'   => esc_url( home_url( '/blog' ) ),
             ],
         ];


### PR DESCRIPTION
## Summary
- Declare and load `IELTS-IMMIGRATION` text domain from `languages`
- Switch admin UI and custom post type strings to new text domain

## Testing
- `php -l ielts-migration.php && php -l includes/class-admin.php && php -l includes/class-custom-posts.php && php -l includes/class-shortcodes-home.php`

------
https://chatgpt.com/codex/tasks/task_e_68bb325fce2c8333a218c4813b48398b