### PR TITLE
Load admin menu only in dashboard

### DIFF
--- a/ielts-migration.php
+++ b/ielts-migration.php
@@ -29,7 +29,10 @@ new IELTS_Shortcodes();
 new IELTS_Shortcodes_Home();
 add_action( 'plugins_loaded', static function() {
     load_plugin_textdomain( 'IELTS-IMMIGRATION', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
-    new IELTS_Admin();
+
+    if ( is_admin() ) {
+        new IELTS_Admin_Menu();
+    }
 } );
 
 if ( file_exists(IELTS_MIGRATION_DIR.'integrations/woocommerce.php') ) require_once IELTS_MIGRATION_DIR.'integrations/woocommerce.php';

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -2,7 +2,7 @@
 /**
  * Admin menu and settings scaffold.
  */
-class IELTS_Admin {
+class IELTS_Admin_Menu {
     /**
      * Menu slug for the plugin dashboard.
      */


### PR DESCRIPTION
## Summary
- Rename admin class to `IELTS_Admin_Menu`
- Instantiate the admin menu only when in the dashboard

## Testing
- `php -l includes/class-admin.php`
- `php -l ielts-migration.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb36b361f08333a41d8f1623f79b74