### PR TITLE
feat: nest post types under plugin menu

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -6,7 +6,7 @@ class IELTS_Admin_Menu {
     /**
      * Menu slug for the plugin dashboard.
      */
-    private const MENU_SLUG = 'ielts-immigration';
+    private const MENU_SLUG = 'ielts_migration';
 
     /**
      * Constructor.
@@ -21,8 +21,8 @@ class IELTS_Admin_Menu {
      */
     public function register_menu() : void {
         add_menu_page(
-            __( 'IELTS Immigration', 'IELTS-IMMIGRATION' ),
-            __( 'IELTS Immigration', 'IELTS-IMMIGRATION' ),
+            __( 'IELTS Migration', 'IELTS-IMMIGRATION' ),
+            __( 'IELTS Migration', 'IELTS-IMMIGRATION' ),
             'manage_options',
             self::MENU_SLUG,
             [ $this, 'render_dashboard' ],
@@ -58,7 +58,7 @@ class IELTS_Admin_Menu {
         }
         ?>
         <div class="wrap">
-            <h1><?php echo esc_html__( 'IELTS Immigration', 'IELTS-IMMIGRATION' ); ?></h1>
+            <h1><?php echo esc_html__( 'IELTS Migration', 'IELTS-IMMIGRATION' ); ?></h1>
 
             <h2 class="title ielts-admin-section"><?php echo esc_html__( 'Overview', 'IELTS-IMMIGRATION' ); ?></h2>
             <p><?php echo esc_html__( 'Coming soon…', 'IELTS-IMMIGRATION' ); ?></p>

--- a/includes/class-custom-posts.php
+++ b/includes/class-custom-posts.php
@@ -22,6 +22,7 @@ class IELTS_Custom_Posts {
             'rewrite'      => [ 'slug' => 'lesson' ],
             'supports'     => [ 'title', 'editor', 'excerpt', 'thumbnail', 'custom-fields' ],
             'menu_icon'    => 'dashicons-welcome-learn-more',
+            'show_in_menu' => 'ielts_migration',
         ] );
 
         register_post_type( 'ielts_kit', [
@@ -35,6 +36,7 @@ class IELTS_Custom_Posts {
             'rewrite'      => [ 'slug' => 'kits' ],
             'supports'     => [ 'title', 'editor', 'excerpt', 'thumbnail', 'custom-fields' ],
             'menu_icon'    => 'dashicons-portfolio',
+            'show_in_menu' => 'ielts_migration',
         ] );
 
         register_post_type( 'ielts_practice', [
@@ -48,6 +50,7 @@ class IELTS_Custom_Posts {
             'rewrite'      => [ 'slug' => 'practice' ],
             'supports'     => [ 'title', 'editor', 'custom-fields' ],
             'menu_icon'    => 'dashicons-edit',
+            'show_in_menu' => 'ielts_migration',
         ] );
     }
 }


### PR DESCRIPTION
## Summary
- show custom post types under IELTS menu
- rename admin menu slug to `ielts_migration`

## Testing
- `php -l includes/class-custom-posts.php`
- `php -l includes/class-admin.php`

## Rollback
- Revert commit 0ebeec5

------
https://chatgpt.com/codex/tasks/task_e_68bb38516f18833386404106714b83b5