### PR TITLE
feat: add IELTS Immigration admin menu

### DIFF
--- a/ielts-migration.php
+++ b/ielts-migration.php
@@ -21,7 +21,6 @@ require_once IELTS_MIGRATION_DIR.'includes/class-shortcodes.php';
 require_once IELTS_MIGRATION_DIR.'includes/class-shortcodes-home.php';
 require_once IELTS_MIGRATION_DIR.'includes/class-rest-api.php';
 require_once IELTS_MIGRATION_DIR.'includes/class-purchases.php';
-require_once IELTS_MIGRATION_DIR.'includes/class-admin.php';
 
 new IELTS_Assets();
 new IELTS_Custom_Posts();
@@ -31,6 +30,7 @@ add_action( 'plugins_loaded', static function() {
     load_plugin_textdomain( 'IELTS-IMMIGRATION', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
 
     if ( is_admin() ) {
+        require_once IELTS_MIGRATION_DIR . 'includes/class-admin.php';
         new IELTS_Admin_Menu();
     }
 } );

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -21,12 +21,36 @@ class IELTS_Admin_Menu {
      */
     public function register_menu() : void {
         add_menu_page(
-            __( 'IELTS Migration', 'IELTS-IMMIGRATION' ),
-            __( 'IELTS Migration', 'IELTS-IMMIGRATION' ),
+            __( 'IELTS Immigration', 'IELTS-IMMIGRATION' ),
+            __( 'IELTS Immigration', 'IELTS-IMMIGRATION' ),
             'manage_options',
             self::MENU_SLUG,
             [ $this, 'render_dashboard' ],
             'dashicons-welcome-learn-more'
+        );
+
+        add_submenu_page(
+            self::MENU_SLUG,
+            __( 'Lessons', 'IELTS-IMMIGRATION' ),
+            __( 'Lessons', 'IELTS-IMMIGRATION' ),
+            'edit_posts',
+            'edit.php?post_type=ielts_lesson'
+        );
+
+        add_submenu_page(
+            self::MENU_SLUG,
+            __( 'Kits', 'IELTS-IMMIGRATION' ),
+            __( 'Kits', 'IELTS-IMMIGRATION' ),
+            'edit_posts',
+            'edit.php?post_type=ielts_kit'
+        );
+
+        add_submenu_page(
+            self::MENU_SLUG,
+            __( 'Practices', 'IELTS-IMMIGRATION' ),
+            __( 'Practices', 'IELTS-IMMIGRATION' ),
+            'edit_posts',
+            'edit.php?post_type=ielts_practice'
         );
     }
 
@@ -58,7 +82,7 @@ class IELTS_Admin_Menu {
         }
         ?>
         <div class="wrap">
-            <h1><?php echo esc_html__( 'IELTS Migration', 'IELTS-IMMIGRATION' ); ?></h1>
+            <h1><?php echo esc_html__( 'IELTS Immigration', 'IELTS-IMMIGRATION' ); ?></h1>
 
             <h2 class="title ielts-admin-section"><?php echo esc_html__( 'Overview', 'IELTS-IMMIGRATION' ); ?></h2>
             <p><?php echo esc_html__( 'Coming soon…', 'IELTS-IMMIGRATION' ); ?></p>

--- a/includes/class-custom-posts.php
+++ b/includes/class-custom-posts.php
@@ -22,6 +22,7 @@ class IELTS_Custom_Posts {
             'rewrite'      => [ 'slug' => 'lesson' ],
             'supports'     => [ 'title', 'editor', 'excerpt', 'thumbnail', 'custom-fields' ],
             'menu_icon'    => 'dashicons-welcome-learn-more',
+            // Nest under the IELTS Immigration menu.
             'show_in_menu' => 'ielts_migration',
         ] );
 
@@ -36,6 +37,7 @@ class IELTS_Custom_Posts {
             'rewrite'      => [ 'slug' => 'kits' ],
             'supports'     => [ 'title', 'editor', 'excerpt', 'thumbnail', 'custom-fields' ],
             'menu_icon'    => 'dashicons-portfolio',
+            // Nest under the IELTS Immigration menu.
             'show_in_menu' => 'ielts_migration',
         ] );
 
@@ -50,6 +52,7 @@ class IELTS_Custom_Posts {
             'rewrite'      => [ 'slug' => 'practice' ],
             'supports'     => [ 'title', 'editor', 'custom-fields' ],
             'menu_icon'    => 'dashicons-edit',
+            // Nest under the IELTS Immigration menu.
             'show_in_menu' => 'ielts_migration',
         ] );
     }


### PR DESCRIPTION
## Summary
- add top-level "IELTS Immigration" menu with CPT submenus
- nest lessons, kits, and practices under the plugin menu
- load admin menu only in dashboard

## Testing steps
1. Activate the plugin on a local WordPress.
2. Visit WP Admin; verify a top-level menu "IELTS Immigration" appears with submenus for Lessons, Kits, Practices.
3. Open each submenu; confirm CPT screens load.
4. Create a Lesson and view it; if 404, resave permalinks.

## Rollback
- Revert this PR or remove `show_in_menu` and `class-admin.php` and re-save permalinks.


------
https://chatgpt.com/codex/tasks/task_e_68bb3dcd481c8333a1790bff99894e93