### PR TITLE
LOG-21: Refactor admin menu & integrate post types under IELTS parent menu

### DIFF
--- a/Project_Log.md
+++ b/Project_Log.md
@@ -45,6 +45,7 @@
 - [❌] P2-09 لاگ سبک دانلود/فعالیت (برای گزارش)
 - [❌] P2-10 واحد تست ساده برای شورتکد و REST
 - [✔️] P2-11 Admin menu & settings scaffold (PR #TBD)
+- [✔️] LOG-21 Refactor admin menu & integrate post types under IELTS parent menu
 
 ---
 

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -5,8 +5,9 @@
 class IELTS_Admin_Menu {
     /**
      * Menu slug for the plugin dashboard.
+     * Exposed so other classes can nest submenus.
      */
-    private const MENU_SLUG = 'ielts_migration';
+    public const MENU_SLUG = 'ielts_migration';
 
     /**
      * Constructor.
@@ -17,7 +18,8 @@ class IELTS_Admin_Menu {
     }
 
     /**
-     * Register top-level menu.
+     * Register top-level plugin menu. Custom post types appear
+     * automatically under this menu via the `show_in_menu` argument.
      */
     public function register_menu() : void {
         add_menu_page(
@@ -27,30 +29,6 @@ class IELTS_Admin_Menu {
             self::MENU_SLUG,
             [ $this, 'render_dashboard' ],
             'dashicons-welcome-learn-more'
-        );
-
-        add_submenu_page(
-            self::MENU_SLUG,
-            __( 'Lessons', 'IELTS-IMMIGRATION' ),
-            __( 'Lessons', 'IELTS-IMMIGRATION' ),
-            'edit_posts',
-            'edit.php?post_type=ielts_lesson'
-        );
-
-        add_submenu_page(
-            self::MENU_SLUG,
-            __( 'Kits', 'IELTS-IMMIGRATION' ),
-            __( 'Kits', 'IELTS-IMMIGRATION' ),
-            'edit_posts',
-            'edit.php?post_type=ielts_kit'
-        );
-
-        add_submenu_page(
-            self::MENU_SLUG,
-            __( 'Practices', 'IELTS-IMMIGRATION' ),
-            __( 'Practices', 'IELTS-IMMIGRATION' ),
-            'edit_posts',
-            'edit.php?post_type=ielts_practice'
         );
     }
 

--- a/includes/class-custom-posts.php
+++ b/includes/class-custom-posts.php
@@ -23,7 +23,7 @@ class IELTS_Custom_Posts {
             'supports'     => [ 'title', 'editor', 'excerpt', 'thumbnail', 'custom-fields' ],
             'menu_icon'    => 'dashicons-welcome-learn-more',
             // Nest under the IELTS Immigration menu.
-            'show_in_menu' => 'ielts_migration',
+            'show_in_menu' => IELTS_Admin_Menu::MENU_SLUG,
         ] );
 
         register_post_type( 'ielts_kit', [
@@ -38,7 +38,7 @@ class IELTS_Custom_Posts {
             'supports'     => [ 'title', 'editor', 'excerpt', 'thumbnail', 'custom-fields' ],
             'menu_icon'    => 'dashicons-portfolio',
             // Nest under the IELTS Immigration menu.
-            'show_in_menu' => 'ielts_migration',
+            'show_in_menu' => IELTS_Admin_Menu::MENU_SLUG,
         ] );
 
         register_post_type( 'ielts_practice', [
@@ -53,7 +53,7 @@ class IELTS_Custom_Posts {
             'supports'     => [ 'title', 'editor', 'custom-fields' ],
             'menu_icon'    => 'dashicons-edit',
             // Nest under the IELTS Immigration menu.
-            'show_in_menu' => 'ielts_migration',
+            'show_in_menu' => IELTS_Admin_Menu::MENU_SLUG,
         ] );
     }
 }


### PR DESCRIPTION
## Summary
- expose admin menu slug for reuse
- remove manual CPT submenu declarations
- nest lesson, kit, practice post types under parent menu slug

## Testing
- `php -l includes/class-admin.php`
- `php -l includes/class-custom-posts.php`
- `php -l ielts-migration.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb5c83cdd48333bcfd2e1adebd514f