### PR TITLE
M3-03: dictation board (JS) + shortcode

### DIFF
--- a/includes/class-shortcodes.php
+++ b/includes/class-shortcodes.php
@@ -5,6 +5,7 @@
 class IELTS_Shortcodes {
     public function __construct() {
         add_shortcode( 'ielts_lessons', [ $this, 'render_lessons' ] );
+        add_shortcode( 'ielts_board', [ $this, 'render_board' ] );
     }
 
     /**
@@ -53,5 +54,55 @@ class IELTS_Shortcodes {
         wp_reset_postdata();
 
         return ob_get_clean();
+    }
+
+    /**
+     * Render interactive board.
+     *
+     * @param array $atts Shortcode attributes.
+     * @return string
+     */
+    public function render_board( $atts ) : string {
+        $atts = shortcode_atts(
+            [
+                'mode' => '',
+                'item' => 0,
+            ],
+            $atts,
+            'ielts_board'
+        );
+
+        $mode = sanitize_text_field( $atts['mode'] );
+        $item = (int) $atts['item'];
+
+        wp_enqueue_style(
+            'ielts-board',
+            IELTS_MIGRATION_URL . 'public/css/board.css',
+            [],
+            IELTS_MIGRATION_VER
+        );
+        wp_enqueue_script( 'wp-api' );
+        wp_enqueue_script(
+            'ielts-board-core',
+            IELTS_MIGRATION_URL . 'public/js/board/core.js',
+            [ 'wp-api' ],
+            IELTS_MIGRATION_VER,
+            true
+        );
+        wp_enqueue_script(
+            'ielts-board-dictation',
+            IELTS_MIGRATION_URL . 'public/js/board/dictation.js',
+            [ 'ielts-board-core' ],
+            IELTS_MIGRATION_VER,
+            true
+        );
+
+        $attrs = sprintf(
+            'class="ielts-board" data-mode="%s" data-item="%d"',
+            esc_attr( $mode ),
+            $item
+        );
+
+        return '<div ' . $attrs . '></div>';
     }
 }

--- a/public/css/board.css
+++ b/public/css/board.css
@@ -1,0 +1,20 @@
+.ielts-board {
+    max-width: 600px;
+    margin: 1em 0;
+}
+
+.ielts-board textarea {
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.ielts-board .ielts-word-count {
+    margin-top: 0.5em;
+    font-size: 0.9em;
+    color: #555;
+}
+
+.ielts-board .ielts-result {
+    margin-top: 1em;
+    font-weight: bold;
+}

--- a/public/js/board/core.js
+++ b/public/js/board/core.js
@@ -1,0 +1,16 @@
+window.IELTSBoard = window.IELTSBoard || {};
+
+// Initialize board after DOM ready.
+IELTSBoard.init = function () {
+    var container = document.querySelector('.ielts-board');
+    if (!container) {
+        return;
+    }
+    var mode = container.dataset.mode;
+    var item = container.dataset.item;
+    if (mode && typeof IELTSBoard[mode] === 'function') {
+        IELTSBoard[mode](container, item);
+    }
+};
+
+document.addEventListener('DOMContentLoaded', IELTSBoard.init);

--- a/public/js/board/dictation.js
+++ b/public/js/board/dictation.js
@@ -1,0 +1,87 @@
+window.IELTSBoard = window.IELTSBoard || {};
+
+IELTSBoard.dictation = function (container, itemId) {
+    var apiRoot = (window.wpApiSettings && wpApiSettings.root) ? wpApiSettings.root : '/wp-json/';
+    var nonce = (window.wpApiSettings && wpApiSettings.nonce) ? wpApiSettings.nonce : '';
+    var state = { text: '' };
+
+    container.innerHTML = '' +
+        '<div class="ielts-audio">' +
+            '<button class="ielts-play" type="button">Play</button>' +
+            '<button class="ielts-rewind" type="button">Rewind 5s</button>' +
+            '<audio class="ielts-audio-el" preload="auto" style="display:none"></audio>' +
+        '</div>' +
+        '<textarea class="ielts-input" rows="6"></textarea>' +
+        '<div class="ielts-word-count">0 words</div>' +
+        '<button class="ielts-check" type="button">Check</button>' +
+        '<div class="ielts-result"></div>';
+
+    var audio = container.querySelector('.ielts-audio-el');
+    var playBtn = container.querySelector('.ielts-play');
+    var rewindBtn = container.querySelector('.ielts-rewind');
+    var textarea = container.querySelector('.ielts-input');
+    var wordCount = container.querySelector('.ielts-word-count');
+    var checkBtn = container.querySelector('.ielts-check');
+    var resultEl = container.querySelector('.ielts-result');
+
+    // Fetch payload to start session
+    fetch(apiRoot + 'ielts/v1/session/start', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'X-WP-Nonce': nonce
+        },
+        body: JSON.stringify({ id: itemId })
+    })
+        .then(function (r) { return r.json(); })
+        .then(function (res) {
+            if (res.ok && res.data) {
+                state.text = res.data.text || '';
+                if (res.data.audio) {
+                    audio.src = res.data.audio;
+                }
+            } else if (res.error) {
+                resultEl.textContent = res.error;
+            }
+        });
+
+    playBtn.addEventListener('click', function () {
+        if (audio.paused) {
+            audio.play();
+            playBtn.textContent = 'Pause';
+        } else {
+            audio.pause();
+            playBtn.textContent = 'Play';
+        }
+    });
+
+    rewindBtn.addEventListener('click', function () {
+        audio.currentTime = Math.max(0, audio.currentTime - 5);
+    });
+
+    textarea.addEventListener('input', function () {
+        var words = textarea.value.trim().split(/\s+/).filter(Boolean);
+        wordCount.textContent = words.length + ' words';
+    });
+
+    checkBtn.addEventListener('click', function () {
+        var answer = textarea.value;
+        fetch(apiRoot + 'ielts/v1/session/finish', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-WP-Nonce': nonce
+            },
+            body: JSON.stringify({ id: itemId, answer: answer })
+        })
+            .then(function (r) { return r.json(); })
+            .then(function (res) {
+                if (res.ok && res.data) {
+                    var wer = res.data.wer ? (res.data.wer * 100).toFixed(1) : '0';
+                    resultEl.innerHTML = '<p>WER: ' + wer + '%</p><p>' + state.text + '</p>';
+                } else if (res.error) {
+                    resultEl.textContent = res.error;
+                }
+            });
+    });
+};


### PR DESCRIPTION
## Summary
- Add `[ielts_board]` shortcode that enqueues board assets and renders interactive container
- Implement `core.js` for board bootstrap and `dictation.js` for REST-driven dictation board with audio controls, word counter and result
- Add basic board styling via `board.css`

## Testing
- `php -l includes/class-shortcodes.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbe500810883338855802139bd0240