### PR TITLE
M3-02: speaking MVP (record/upload/playback)

### DIFF
--- a/includes/class-rest-api.php
+++ b/includes/class-rest-api.php
@@ -117,6 +117,37 @@ add_action( 'rest_api_init', function() {
         },
         'permission_callback' => '__return_true',
     ] );
+
+    register_rest_route( 'ielts/v1', '/speaking', [
+        'methods'  => 'POST',
+        'callback' => function( WP_REST_Request $req ) {
+            $nonce = $req->get_header( 'X-WP-Nonce' );
+            if ( ! wp_verify_nonce( $nonce, 'wp_rest' ) ) {
+                return rest_ensure_response( [ 'ok' => false, 'error' => __( 'Invalid nonce', 'ielts-migration' ) ] );
+            }
+            if ( ! is_user_logged_in() || ! current_user_can( 'upload_files' ) ) {
+                return rest_ensure_response( [ 'ok' => false, 'error' => __( 'Unauthorized', 'ielts-migration' ) ] );
+            }
+            $item_id = absint( $req->get_param( 'item' ) );
+            $files   = $req->get_file_params();
+            if ( empty( $files['file'] ) ) {
+                return rest_ensure_response( [ 'ok' => false, 'error' => __( 'No file', 'ielts-migration' ) ] );
+            }
+            require_once ABSPATH . 'wp-admin/includes/file.php';
+            require_once ABSPATH . 'wp-admin/includes/media.php';
+            require_once ABSPATH . 'wp-admin/includes/image.php';
+            $attachment_id = media_handle_sideload( $files['file'], $item_id, null, [
+                'post_status' => 'private',
+                'post_author' => get_current_user_id(),
+            ] );
+            if ( is_wp_error( $attachment_id ) ) {
+                return rest_ensure_response( [ 'ok' => false, 'error' => $attachment_id->get_error_message() ] );
+            }
+            update_user_meta( get_current_user_id(), 'ielts_speaking_' . $item_id, $attachment_id );
+            return rest_ensure_response( [ 'ok' => true, 'url' => wp_get_attachment_url( $attachment_id ) ] );
+        },
+        'permission_callback' => '__return_true',
+    ] );
 } );
 
 /**

--- a/includes/class-shortcodes.php
+++ b/includes/class-shortcodes.php
@@ -89,13 +89,23 @@ class IELTS_Shortcodes {
             IELTS_MIGRATION_VER,
             true
         );
-        wp_enqueue_script(
-            'ielts-board-dictation',
-            IELTS_MIGRATION_URL . 'public/js/board/dictation.js',
-            [ 'ielts-board-core' ],
-            IELTS_MIGRATION_VER,
-            true
-        );
+        if ( 'dictation' === $mode ) {
+            wp_enqueue_script(
+                'ielts-board-dictation',
+                IELTS_MIGRATION_URL . 'public/js/board/dictation.js',
+                [ 'ielts-board-core' ],
+                IELTS_MIGRATION_VER,
+                true
+            );
+        } elseif ( 'speaking' === $mode ) {
+            wp_enqueue_script(
+                'ielts-board-speaking',
+                IELTS_MIGRATION_URL . 'public/js/board/speaking.js',
+                [ 'ielts-board-core' ],
+                IELTS_MIGRATION_VER,
+                true
+            );
+        }
 
         $attrs = sprintf(
             'class="ielts-board" data-mode="%s" data-item="%d"',

--- a/public/css/board.css
+++ b/public/css/board.css
@@ -8,6 +8,10 @@
     box-sizing: border-box;
 }
 
+.ielts-board .ielts-timer {
+    margin-top: 0.5em;
+}
+
 .ielts-board .ielts-word-count {
     margin-top: 0.5em;
     font-size: 0.9em;

--- a/public/js/board/speaking.js
+++ b/public/js/board/speaking.js
@@ -1,0 +1,67 @@
+window.IELTSBoard = window.IELTSBoard || {};
+
+IELTSBoard.speaking = function (container, itemId) {
+    var apiRoot = (window.wpApiSettings && wpApiSettings.root) ? wpApiSettings.root : '/wp-json/';
+    var nonce = (window.wpApiSettings && wpApiSettings.nonce) ? wpApiSettings.nonce : '';
+    var mediaRecorder;
+    var chunks = [];
+    var timer = null;
+    var seconds = 0;
+
+    container.innerHTML = '' +
+        '<button class="ielts-record" type="button">Record</button>' +
+        '<div class="ielts-timer">0s</div>' +
+        '<audio class="ielts-playback" controls style="display:none"></audio>';
+
+    var recordBtn = container.querySelector('.ielts-record');
+    var timerEl = container.querySelector('.ielts-timer');
+    var playback = container.querySelector('.ielts-playback');
+
+    recordBtn.addEventListener('click', function () {
+        if (mediaRecorder && mediaRecorder.state === 'recording') {
+            mediaRecorder.stop();
+            recordBtn.disabled = true;
+        } else {
+            navigator.mediaDevices.getUserMedia({ audio: true }).then(function (stream) {
+                mediaRecorder = new MediaRecorder(stream);
+                chunks = [];
+                mediaRecorder.ondataavailable = function (e) {
+                    if (e.data.size > 0) {
+                        chunks.push(e.data);
+                    }
+                };
+                mediaRecorder.onstop = function () {
+                    clearInterval(timer);
+                    timer = null;
+                    recordBtn.disabled = false;
+                    recordBtn.textContent = 'Record';
+                    seconds = 0;
+                    timerEl.textContent = '0s';
+
+                    var blob = new Blob(chunks, { type: 'audio/webm' });
+                    var fd = new FormData();
+                    fd.append('file', blob, 'speaking.webm');
+                    fd.append('item', itemId);
+                    fetch(apiRoot + 'ielts/v1/speaking', {
+                        method: 'POST',
+                        headers: { 'X-WP-Nonce': nonce },
+                        body: fd
+                    })
+                        .then(function (r) { return r.json(); })
+                        .then(function (res) {
+                            if (res.ok && res.url) {
+                                playback.src = res.url;
+                                playback.style.display = 'block';
+                            }
+                        });
+                };
+                mediaRecorder.start();
+                recordBtn.textContent = 'Stop';
+                timer = setInterval(function () {
+                    seconds++;
+                    timerEl.textContent = seconds + 's';
+                }, 1000);
+            });
+        }
+    });
+};


### PR DESCRIPTION
## Summary
- add speaking board with in-browser recording, timer, upload and playback
- expose `/speaking` REST route saving uploaded audio to media library privately
- load board scripts conditionally and style timer element

## Testing
- `php -l includes/class-rest-api.php`
- `php -l includes/class-shortcodes.php`
- `node --check public/js/board/speaking.js`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe91a30608333ac35e4bfa41f19f8