### PR TITLE
Register and localize assets

### DIFF
--- a/includes/class-assets.php
+++ b/includes/class-assets.php
@@ -1,28 +1,48 @@
 <?php
-/**
- * Manage plugin assets.
- */
+if ( ! defined('ABSPATH') ) exit;
+
 class IELTS_Assets {
     public function __construct() {
-        add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_frontend' ] );
+        add_action('wp_enqueue_scripts', [$this, 'front']);
+        add_action('admin_enqueue_scripts', [$this, 'admin']);
     }
 
-    /**
-     * Enqueue frontend assets when needed.
-     */
-    public function enqueue_frontend() : void {
-        if ( ! is_singular() ) {
-            return;
-        }
+    public function admin() {
+        wp_register_style(
+            'exam-board-admin',
+            IELTS_MIGRATION_URL.'public/css/admin.css',
+            [],
+            IELTS_MIGRATION_VER
+        );
+    }
 
-        global $post;
-        if ( isset( $post->post_content ) && has_shortcode( $post->post_content, 'ielts_lessons' ) ) {
-            wp_enqueue_style(
-                'ielts-frontend',
-                IELTS_MIGRATION_URL . 'public/css/frontend.css',
-                [],
-                IELTS_MIGRATION_VER
-            );
-        }
+    public function front() {
+        wp_register_style(
+            'exam-board-front',
+            IELTS_MIGRATION_URL.'public/css/board.css',
+            [],
+            IELTS_MIGRATION_VER
+        );
+
+        wp_register_script(
+            'exam-board-front',
+            IELTS_MIGRATION_URL.'public/js/board.js',
+            [],
+            IELTS_MIGRATION_VER,
+            true
+        );
+
+        wp_localize_script('exam-board-front', 'ExamBoard', [
+            'rest'  => [
+                'url'   => esc_url_raw( rest_url('examb/v1/') ),
+                'nonce' => wp_create_nonce('wp_rest'),
+            ],
+            'i18n'  => [
+                'recording' => __('Recording...', 'ielts-migration'),
+                'unsupported' => __('Not supported in this browser.', 'ielts-migration'),
+                'uploading' => __('Uploading...', 'ielts-migration'),
+                'saved' => __('Saved', 'ielts-migration'),
+            ],
+        ]);
     }
 }


### PR DESCRIPTION
## Summary
- Register admin and frontend assets
- Add localized frontend script with REST data and messages

## Testing
- `php -l includes/class-assets.php`

------
https://chatgpt.com/codex/tasks/task_e_68bc7f0d0fd08333baa81dd93acc720e